### PR TITLE
Add instructions for installation into Vim 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Installation
 *Prima facie* can be installed using any of the plugin management tools 
 available for vim:
 
+### **Vim 8 native packaging**
+
+Clone this repository into your ``.vim/pack/*/start/`` directory:
+
+    cd ~/.vim/pack/plugin/start
+    git clone git://github.com/kalekundert/vim-prima-facie.git
+
+
+
 ### [pathogen](https://github.com/tpope/vim-pathogen)
 
 Clone this repository into your ``.vim/bundle`` directory:


### PR DESCRIPTION
Vim 8 has support for plugin (or “pack”) loading built right in. It works almost exactly the same as Pathogen — you simply put the package tree into a folder, so I just copied and modified the directions to fit. 

Since Vim 8 is the version most systems will give you now either by default or after installing a `vim` package, I also put it on top of the list.